### PR TITLE
Use env variable for API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,5 +9,6 @@
 
 ## Запуск
 ```bash
+# переменная окружения OPENAI_API_KEY должна содержать ваш токен
 OPENAI_API_KEY=... python main.py [--voice alloy] [--debug]
 ```

--- a/chat_client.py
+++ b/chat_client.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import os
 import time
 from typing import AsyncIterator
 
@@ -9,8 +10,12 @@ import config
 
 
 class ChatClient:
-    def __init__(self, api_key: str, debug: bool = False):
+    def __init__(self, api_key: str | None = None, debug: bool = False):
         self.debug = debug
+        if api_key is None:
+            api_key = os.environ.get("OPENAI_API_KEY")
+        if not api_key:
+            raise RuntimeError("OPENAI_API_KEY environment variable is not set")
         self.client = openai.AsyncOpenAI(
             api_key=api_key,
             base_url=config.BASE_URL,

--- a/main.py
+++ b/main.py
@@ -1,7 +1,6 @@
 import argparse
 import asyncio
 import logging
-import os
 
 import config
 from chat_client import ChatClient
@@ -27,14 +26,11 @@ async def run():
         format="[%(asctime)s] %(levelname)s: %(message)s",
     )
 
-    api_key = os.environ.get("OPENAI_API_KEY")
-    if not api_key:
-        print(
-            "\u041d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d API \u043a\u043b\u044e\u0447 (OPENAI_API_KEY)"
-        )
+    try:
+        client = ChatClient(debug=args.debug)
+    except RuntimeError as e:
+        print(e)
         return
-
-    client = ChatClient(api_key=api_key, debug=args.debug)
 
     print(
         "GPT-TTS CLI. \u0412\u0432\u0435\u0434\u0438\u0442\u0435 \u0437\u0430\u043f\u0440\u043e\u0441. \u0414\u043b\u044f \u0432\u044b\u0445\u043e\u0434\u0430: /exit, q"


### PR DESCRIPTION
## Summary
- fetch OPENAI_API_KEY from environment in `ChatClient`
- rely on this in `main.py`
- clarify token usage in README

## Testing
- `python -m py_compile *.py`
- `OPENAI_API_KEY=dummy python main.py --help | head`

------
https://chatgpt.com/codex/tasks/task_e_6854659d28a48329897248ee289de2d6