### PR TITLE
Add .env support for API token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 __pycache__/
+
+.env

--- a/README.md
+++ b/README.md
@@ -6,9 +6,12 @@
 - Python 3.10+
 - openai 1.x
 - ffplay (из пакета ffmpeg)
+- python-dotenv
 
 ## Запуск
 ```bash
 # переменная окружения OPENAI_API_KEY должна содержать ваш токен
+# можно создать файл `.env` с записью `OPENAI_API_KEY=...`
+# тогда ключ будет загружен автоматически
 OPENAI_API_KEY=... python main.py [--voice alloy] [--debug]
 ```

--- a/main.py
+++ b/main.py
@@ -3,11 +3,13 @@ import asyncio
 import logging
 
 import config
+from dotenv import load_dotenv
 from chat_client import ChatClient
 from player import play_stream
 
 
 async def run():
+    load_dotenv()
     parser = argparse.ArgumentParser(description="GPT-TTS CLI")
     parser.add_argument(
         "--debug",


### PR DESCRIPTION
## Summary
- load environment variables from `.env`
- document `.env` usage and `python-dotenv` dependency
- ignore `.env` in git

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_6854679c7ccc8329bfe29e9a800d145c