### PR TITLE
Add CLI token management

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,6 @@
 ```bash
 # переменная окружения OPENAI_API_KEY должна содержать ваш токен
 # можно создать файл `.env` с записью `OPENAI_API_KEY=...`
-# тогда ключ будет загружен автоматически
-OPENAI_API_KEY=... python main.py [--voice alloy] [--debug]
+# или передать ключ параметром `--token`. Опция `--save-token` сохраняет его в `.env`
+OPENAI_API_KEY=... python main.py [--token KEY] [--save-token] [--voice alloy] [--debug]
 ```

--- a/main.py
+++ b/main.py
@@ -1,9 +1,11 @@
 import argparse
 import asyncio
 import logging
+import os
 
 import config
-from dotenv import load_dotenv
+from dotenv import load_dotenv, set_key
+from pathlib import Path
 from chat_client import ChatClient
 from player import play_stream
 
@@ -21,7 +23,22 @@ async def run():
         default=config.DEFAULT_VOICE,
         help="\u0433\u043e\u043b\u043e\u0441 TTS",
     )
+    parser.add_argument(
+        "--token",
+        help="OpenAI API key",
+    )
+    parser.add_argument(
+        "--save-token",
+        action="store_true",
+        help="save provided token to .env",
+    )
     args = parser.parse_args()
+
+    if args.token:
+        os.environ["OPENAI_API_KEY"] = args.token
+        if args.save_token:
+            env_path = Path(".env")
+            set_key(env_path, "OPENAI_API_KEY", args.token)
 
     logging.basicConfig(
         level=logging.DEBUG if args.debug else logging.INFO,
@@ -29,7 +46,7 @@ async def run():
     )
 
     try:
-        client = ChatClient(debug=args.debug)
+        client = ChatClient(api_key=args.token, debug=args.debug)
     except RuntimeError as e:
         print(e)
         return


### PR DESCRIPTION
## Summary
- support supplying API token via `--token` and optional saving to `.env`
- document new options in README

## Testing
- `ruff check .`
- `python -m py_compile chat_client.py main.py player.py config.py`
- `python main.py --help` *(fails: ModuleNotFoundError: No module named 'openai')*


------
https://chatgpt.com/codex/tasks/task_e_68546cfe7eec8329953fbf7ea4e00f72