### PR TITLE
Document required dependency versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,18 @@
 ## Требования
 - Python 3.10+
 - openai 1.x
+- httpx < 0.28
 - ffplay (из пакета ffmpeg)
 - python-dotenv
+
+Все зависимости можно установить командой:
+
+```bash
+pip install -r requirements.txt
+```
+
+Если при запуске появляется ошибка вида `AsyncClient.__init__() got an unexpected`
+` keyword argument 'proxies'`, убедитесь, что используется версия `httpx` ниже `0.28`.
 
 ## Запуск
 ```bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+openai>=1.0,<2.0
+httpx<0.28
+python-dotenv


### PR DESCRIPTION
## Summary
- add minimal requirements.txt
- update README with dependency installation instructions and note about `httpx` version

## Testing
- `python -m py_compile chat_client.py main.py player.py config.py`
- `pip install --force-reinstall -r requirements.txt`
- `python main.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68546f75151083298c34114472c986a7