### PR TITLE
Use httpx directly for requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@
 
 ## Требования
 - Python 3.10+
-- openai 1.x
-- httpx < 0.28
+- httpx >= 0.28
 - ffplay (из пакета ffmpeg)
 - python-dotenv
 
@@ -15,8 +14,7 @@
 pip install -r requirements.txt
 ```
 
-Если при запуске появляется ошибка вида `AsyncClient.__init__() got an unexpected`
-` keyword argument 'proxies'`, убедитесь, что используется версия `httpx` ниже `0.28`.
+Клиент использует [httpx](https://www.python-httpx.org/) напрямую и не зависит от библиотеки `openai`, поэтому конфликт версий `httpx` исключён.
 
 ## Запуск
 ```bash

--- a/chat_client.py
+++ b/chat_client.py
@@ -4,7 +4,7 @@ import os
 import time
 from typing import AsyncIterator
 
-import openai
+import httpx
 
 import config
 
@@ -16,10 +16,11 @@ class ChatClient:
             api_key = os.environ.get("OPENAI_API_KEY")
         if not api_key:
             raise RuntimeError("OPENAI_API_KEY environment variable is not set")
-        self.client = openai.AsyncOpenAI(
-            api_key=api_key,
+        self._headers = {"Authorization": f"Bearer {api_key}"}
+        self.client = httpx.AsyncClient(
             base_url=config.BASE_URL,
             timeout=config.TIMEOUT,
+            headers=self._headers,
         )
 
     async def _request_with_retry(self, func, *args, **kwargs):
@@ -27,25 +28,27 @@ class ChatClient:
             try:
                 start = time.monotonic()
                 resp = await func(*args, **kwargs)
+                resp.raise_for_status()
                 elapsed = time.monotonic() - start
                 logging.debug("Request took %.2fs", elapsed)
                 return resp
-            except openai.APIStatusError as e:
-                if 500 <= e.status_code < 600:
+            except httpx.HTTPStatusError as e:
+                status = e.response.status_code
+                if 500 <= status < 600:
                     delay = config.RETRY_BACKOFF**attempt
                     logging.warning(
-                        "Server %s error, retry in %s s", e.status_code, delay
+                        "Server %s error, retry in %s s", status, delay
                     )
                     await asyncio.sleep(delay)
                     continue
-                if e.status_code == 429:
+                if status == 429:
                     logging.warning(
                         "\u041f\u0440\u0435\u0432\u044b\u0448\u0435\u043d \u043b\u0438\u043c\u0438\u0442 \u0437\u0430\u043f\u0440\u043e\u0441\u043e\u0432, \u0436\u0434\u0451\u043c 20 \u0441"
                     )
                     await asyncio.sleep(20)
                     continue
                 raise
-            except (openai.APITimeoutError, openai.APIConnectionError) as e:
+            except (httpx.TimeoutException, httpx.TransportError) as e:
                 delay = config.RETRY_BACKOFF**attempt
                 logging.warning("Network error %s, retry in %s s", e, delay)
                 await asyncio.sleep(delay)
@@ -62,15 +65,17 @@ class ChatClient:
         if self.debug:
             logging.debug("Chat payload: %s", payload)
         resp = await self._request_with_retry(
-            self.client.chat.completions.create, **payload
+            self.client.post, "/chat/completions", json=payload
         )
-        if self.debug and resp.usage is not None:
+        data = resp.json()
+        if self.debug and data.get("usage"):
+            usage = data["usage"]
             logging.debug(
                 "Tokens: prompt %s, completion %s",
-                resp.usage.prompt_tokens,
-                resp.usage.completion_tokens,
+                usage.get("prompt_tokens"),
+                usage.get("completion_tokens"),
             )
-        return resp.choices[0].message.content.strip()
+        return data["choices"][0]["message"]["content"].strip()
 
     async def tts(
         self, text: str, voice: str = config.DEFAULT_VOICE, fmt: str = "mp3"
@@ -85,5 +90,10 @@ class ChatClient:
         if self.debug:
             dbg = {k: v for k, v in params.items() if k != "input"}
             logging.debug("TTS params: %s", dbg)
-        resp = await self._request_with_retry(self.client.audio.speech.create, **params)
+        resp = await self._request_with_retry(
+            self.client.post, "/audio/speech", json=params
+        )
         return resp.aiter_bytes()
+
+    async def close(self) -> None:
+        await self.client.aclose()

--- a/main.py
+++ b/main.py
@@ -71,6 +71,7 @@ async def run():
         except Exception as e:
             logging.error("%s", e)
     print("\u0414\u043e \u0441\u0432\u0438\u0434\u0430\u043d\u0438\u044f!")
+    await client.close()
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-openai>=1.0,<2.0
-httpx<0.28
+httpx>=0.28
 python-dotenv


### PR DESCRIPTION
## Summary
- remove openai dependency and call API with httpx
- update requirements and docs
- close the async client when exiting

## Testing
- `python -m py_compile *.py`
- `python main.py --help`

------
https://chatgpt.com/codex/tasks/task_e_685471eee6488329b0dc0e0a0cccb14f