### PR TITLE
Improve CLI features and audio playback

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # GPT-TTS CLI
 
-Консольный бот для общения с моделью GPT-4.1 с озвучкой ответов.
+Консольный бот для общения с моделью GPT-4.1 с озвучкой ответов. Если `ffplay` недоступен, используется модуль `playsound`.
 
 ## Требования
 - Python 3.10+
 - httpx >= 0.28
-- ffplay (из пакета ffmpeg)
+- ffplay (из пакета ffmpeg) или модуль `playsound`
 - python-dotenv
 
 Все зависимости можно установить командой:
@@ -15,11 +15,12 @@ pip install -r requirements.txt
 ```
 
 Клиент использует [httpx](https://www.python-httpx.org/) напрямую и не зависит от библиотеки `openai`, поэтому конфликт версий `httpx` исключён.
+Опцией `--system` можно задать системный промпт для инициализации диалога.
 
 ## Запуск
 ```bash
 # переменная окружения OPENAI_API_KEY должна содержать ваш токен
 # можно создать файл `.env` с записью `OPENAI_API_KEY=...`
 # или передать ключ параметром `--token`. Опция `--save-token` сохраняет его в `.env`
-OPENAI_API_KEY=... python main.py [--token KEY] [--save-token] [--voice alloy] [--debug]
+OPENAI_API_KEY=... python main.py [--token KEY] [--save-token] [--voice alloy] [--system "text"] [--debug]
 ```

--- a/main.py
+++ b/main.py
@@ -28,6 +28,11 @@ async def run():
         help="OpenAI API key",
     )
     parser.add_argument(
+        "--system",
+        default="",
+        help="system prompt",
+    )
+    parser.add_argument(
         "--save-token",
         action="store_true",
         help="save provided token to .env",
@@ -46,7 +51,11 @@ async def run():
     )
 
     try:
-        client = ChatClient(api_key=args.token, debug=args.debug)
+        client = ChatClient(
+            api_key=args.token,
+            debug=args.debug,
+            system_prompt=args.system,
+        )
     except RuntimeError as e:
         print(e)
         return

--- a/player.py
+++ b/player.py
@@ -1,28 +1,47 @@
 import asyncio
 import logging
+import os
 import shutil
+import tempfile
+
+try:
+    from playsound import playsound
+except Exception:  # pragma: no cover - optional dependency
+    playsound = None
 
 
 async def play_stream(chunks):
-    """Play audio chunks using ffplay if available."""
-    if not shutil.which("ffplay"):
-        logging.error("ffplay not found. Cannot play audio stream.")
-        async for _ in chunks:
-            pass
+    """Play audio chunks using ffplay if available or playsound as fallback."""
+    if shutil.which("ffplay"):
+        proc = await asyncio.create_subprocess_exec(
+            "ffplay",
+            "-autoexit",
+            "-nodisp",
+            "-loglevel",
+            "quiet",
+            "-",
+            stdin=asyncio.subprocess.PIPE,
+        )
+        async for chunk in chunks:
+            if proc.stdin is not None:
+                proc.stdin.write(chunk)
+                await proc.stdin.drain()
+        if proc.stdin:
+            proc.stdin.close()
+        await proc.wait()
         return
-    proc = await asyncio.create_subprocess_exec(
-        "ffplay",
-        "-autoexit",
-        "-nodisp",
-        "-loglevel",
-        "quiet",
-        "-",
-        stdin=asyncio.subprocess.PIPE,
-    )
-    async for chunk in chunks:
-        if proc.stdin is not None:
-            proc.stdin.write(chunk)
-            await proc.stdin.drain()
-    if proc.stdin:
-        proc.stdin.close()
-    await proc.wait()
+
+    if playsound:
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".mp3") as tmp:
+            async for chunk in chunks:
+                tmp.write(chunk)
+            tmp_path = tmp.name
+        try:
+            playsound(tmp_path)
+        finally:
+            os.unlink(tmp_path)
+        return
+
+    logging.error("No audio player available. Install ffmpeg or playsound module.")
+    async for _ in chunks:
+        pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 httpx>=0.28
 python-dotenv
+playsound==1.2.2


### PR DESCRIPTION
## Summary
- add `--system` option for system prompt initialization
- maintain last 40 messages in `ChatClient`
- add audio playback fallback using `playsound`
- update requirements and documentation

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt --dry-run`

------
https://chatgpt.com/codex/tasks/task_e_68547395be3483298f89c4518ed4a41b