### PR TITLE
Enable VTube Studio lip sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,11 @@ pip install -r requirements.txt
 # или передать ключ параметром `--token`. Опция `--save-token` сохраняет его в `.env`
 OPENAI_API_KEY=... python main.py [--token KEY] [--save-token] [--voice alloy] [--system "text"] [--debug]
 ```
+
+### Lip sync c VTube Studio
+
+Запустите программу с флагом `--vtube` (или `-v`), чтобы
+синхронизировать параметр `MouthOpen` модели VTube Studio с громкостью
+озвучки. Приложение подключится к VTube Studio по адресу
+`ws://127.0.0.1:8001`. Не забудьте включить доступ к WebSocket API в
+настройках VTube Studio.

--- a/vtube.py
+++ b/vtube.py
@@ -117,8 +117,16 @@ class VTubeClient:
         self._level = min(max(self._level, 0.0), 1.0)
         try:
             payload = {
-                "apiName": "VTubeStudioParameterUpdate",
-                "parameters": [{"name": self.param, "value": self._level}],
+                "apiName": "VTubeStudioPublicAPI",
+                "apiVersion": "1.0",
+                "requestID": str(uuid.uuid4()),
+                "messageType": "InjectParameterDataRequest",
+                "data": {
+                    "mode": "set",
+                    "parameterValues": [
+                        {"id": self.param, "value": self._level, "weight": 1.0}
+                    ],
+                },
             }
             await self._ws.send(json.dumps(payload))
             logging.debug("WS send: %s", payload)


### PR DESCRIPTION
## Summary
- send mouth tracking updates using `InjectParameterDataRequest`
- document how to enable VTube Studio integration

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_68548eb9c4748329b4d49154c857e6a3