### PR TITLE
Add vtube enable option via config

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,11 @@ pip install -r requirements.txt
 # переменная окружения OPENAI_API_KEY должна содержать ваш токен
 # можно создать файл `.env` с записью `OPENAI_API_KEY=...`
 # или передать ключ параметром `--token`. Опция `--save-token` сохраняет его в `.env`
-OPENAI_API_KEY=... python main.py [--token KEY] [--save-token] [--voice alloy] [--system "text"] [--debug]
+OPENAI_API_KEY=... python main.py [--token KEY] [--save-token] [--voice alloy] [--system "text"] [--debug] [--vtube/--no-vtube]
 ```
+
+Опцию использования VTube Studio можно заранее указать в `config.py`,
+изменив значение `ENABLE_VTUBE` на `True` или `False`.
 
 ### Lip sync c VTube Studio
 

--- a/config.py
+++ b/config.py
@@ -9,3 +9,6 @@ MAX_RETRIES = 3
 RETRY_BACKOFF = 2
 # Default system prompt used to initialize conversation history
 SYSTEM_PROMPT = ""
+
+# Enable VTube Studio lip sync by default. Can be overridden with --vtube/--no-vtube
+ENABLE_VTUBE = False

--- a/main.py
+++ b/main.py
@@ -41,8 +41,9 @@ async def run():
     parser.add_argument(
         "-v",
         "--vtube",
-        action="store_true",
-        help="enable VTube Studio lip sync",
+        action=argparse.BooleanOptionalAction,
+        default=config.ENABLE_VTUBE,
+        help="enable or disable VTube Studio lip sync",
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
## Summary
- allow enabling VTube Studio lip sync from `config.py`
- mention optional `--vtube/--no-vtube` flag in the usage
- document configuring VTube via `ENABLE_VTUBE`

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6854910cc744832986f8033bd6b0bf9c