### PR TITLE
Add pinned requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-httpx>=0.28
-python-dotenv
+httpx==0.28.1
+python-dotenv==1.1.0
 playsound==1.2.2
-numpy
-websockets>=11
+numpy==2.3.0
+websockets==15.0.1


### PR DESCRIPTION
## Summary
- specify exact versions for httpx, python-dotenv, playsound, numpy, and websockets

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_685494eb86008329ab58defcc6daa108