### PR TITLE
Use ffplay instead of playsound

### DIFF
--- a/player.py
+++ b/player.py
@@ -1,18 +1,34 @@
 import asyncio
-import logging
-import os
-import shutil
+import subprocess
 import tempfile
+import os
+import logging
 from typing import AsyncIterator, Optional
 
 import numpy as np
 
 from vtube import VTubeClient
 
-try:
-    from playsound import playsound
-except Exception:  # pragma: no cover - optional dependency
-    playsound = None
+
+FFPLAY_PATH = os.path.join("ffmpeg", "bin", "ffplay.exe")
+
+
+def play_file_ffplay(path: str):
+    if not os.path.exists(FFPLAY_PATH):
+        logging.warning("ffplay.exe не найден: %s", FFPLAY_PATH)
+        return
+    if not os.path.exists(path):
+        logging.warning("Файл для воспроизведения не найден: %s", path)
+        return
+    try:
+        subprocess.run(
+            [FFPLAY_PATH, "-nodisp", "-autoexit", path],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=True,
+        )
+    except Exception as e:
+        logging.error("Ошибка при воспроизведении: %s", e)
 
 
 def _rms_level(data: bytes) -> float:
@@ -29,50 +45,17 @@ async def play_stream(
     pcm: bool = False,
     vtube: Optional[VTubeClient] = None,
 ) -> None:
-    """Play audio chunks using ffplay if available or playsound as fallback.
-
-    Args:
-        chunks: Stream of audio bytes.
-        pcm: ``True`` if ``chunks`` provide raw PCM s16le 24 kHz mono.
-        vtube: Optional ``VTubeClient`` for lip sync updates.
-    """
-    if shutil.which("ffplay"):
-        cmd = [
-            "ffplay",
-            "-autoexit",
-            "-nodisp",
-            "-loglevel",
-            "quiet",
-        ]
-        if pcm:
-            cmd += ["-f", "s16le", "-ar", "24000", "-ac", "1"]
-        cmd.append("-")
-        proc = await asyncio.create_subprocess_exec(
-            *cmd, stdin=asyncio.subprocess.PIPE
-        )
-        async for chunk in chunks:
-            if vtube and pcm:
-                level = _rms_level(chunk)
-                asyncio.create_task(vtube.send_level(level))
-            if proc.stdin is not None:
-                proc.stdin.write(chunk)
-                await proc.stdin.drain()
-        if proc.stdin:
-            proc.stdin.close()
-        await proc.wait()
-        return
-
-    if playsound and not pcm:
+    """Save audio stream to a temp file and play it using ffplay."""
+    tmp_path = ""
+    try:
         with tempfile.NamedTemporaryFile(delete=False, suffix=".mp3") as tmp:
             async for chunk in chunks:
+                if vtube and pcm:
+                    level = _rms_level(chunk)
+                    asyncio.create_task(vtube.send_level(level))
                 tmp.write(chunk)
             tmp_path = tmp.name
-        try:
-            playsound(tmp_path)
-        finally:
-            os.unlink(tmp_path)
-        return
-
-    logging.error("No audio player available. Install ffmpeg or playsound module.")
-    async for _ in chunks:
-        pass
+        play_file_ffplay(tmp_path)
+    finally:
+        if tmp_path and os.path.exists(tmp_path):
+            os.remove(tmp_path)


### PR DESCRIPTION
## Summary
- rely on local `ffplay.exe` to play audio
- write chunks to a temp file and launch ffplay
- remove playsound fallback

## Testing
- `python -m py_compile player.py main.py chat_client.py vtube.py vts_handshake.py config.py`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854f76f76b08329b87840ba4a285488