### PR TITLE
Add VTS ping example

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,11 @@ OPENAI_API_KEY=... python main.py [--token KEY] [--save-token] [--voice alloy] [
 озвучки. Приложение подключится к VTube Studio по адресу
 `ws://127.0.0.1:8001`. Не забудьте включить доступ к WebSocket API в
 настройках VTube Studio.
+
+### Проверка связи с VTube Studio
+
+Скрипт `vts_ping.py` отправляет тестовые значения параметра `MouthOpen`, чтобы убедиться в работе подключения. Его можно запустить отдельно:
+```bash
+python vts_ping.py
+```
+

--- a/vts_ping.py
+++ b/vts_ping.py
@@ -1,0 +1,53 @@
+import asyncio
+import json
+import uuid
+import websockets
+
+WS_URL = "ws://127.0.0.1:8001"
+PARAM_ID = "MouthOpen"  # change this if you want another parameter
+PLUGIN = {"pluginName": "GPT-TTS test", "pluginDeveloper": "You"}
+
+rid = lambda: str(uuid.uuid4())
+
+async def main():
+    async with websockets.connect(WS_URL) as ws:
+        # 1. AuthenticationTokenRequest
+        await ws.send(json.dumps({
+            "apiName": "VTubeStudioPublicAPI",
+            "apiVersion": "1.0",
+            "requestID": rid(),
+            "messageType": "AuthenticationTokenRequest",
+            "data": PLUGIN,
+        }))
+        token = json.loads(await ws.recv())["data"]["authenticationToken"]
+
+        # 2. AuthenticationRequest
+        await ws.send(json.dumps({
+            "apiName": "VTubeStudioPublicAPI",
+            "apiVersion": "1.0",
+            "requestID": rid(),
+            "messageType": "AuthenticationRequest",
+            "data": {**PLUGIN, "authenticationToken": token},
+        }))
+        print("Auth response:", await ws.recv())
+
+        # 3. Open and close the mouth three times
+        for _ in range(3):
+            for v in (1.0, 0.0):
+                await ws.send(json.dumps({
+                    "apiName": "VTubeStudioPublicAPI",
+                    "apiVersion": "1.0",
+                    "requestID": rid(),
+                    "messageType": "InjectParameterDataRequest",
+                    "data": {
+                        "mode": "set",
+                        "parameterValues": [
+                            {"id": PARAM_ID, "value": v, "weight": 1.0},
+                        ],
+                    },
+                }))
+                print("Resp:", await ws.recv())
+                await asyncio.sleep(0.4)
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- add a simple `vts_ping.py` script to test mouth parameter injection
- document the script in the README

## Testing
- `python -m py_compile vts_ping.py vtube.py main.py player.py chat_client.py config.py vts_handshake.py`

------
https://chatgpt.com/codex/tasks/task_e_685501aa66588329ba3e728ac36398ba