### PR TITLE
Route audio output to VB-CABLE

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 - httpx >= 0.28
 - ffplay (из пакета ffmpeg) или модуль `playsound`
 - python-dotenv
+- VB-CABLE установлен, VTS Lip-Sync микрофон = CABLE Output
 
 Все зависимости можно установить командой:
 
@@ -43,5 +44,9 @@ OPENAI_API_KEY=... python main.py [--token KEY] [--save-token] [--voice alloy] [
 ```bash
 python vts_ping.py
 ```
+
+### Как слушать звук самому
+
+Для мониторинга аудио используйте VoiceMeeter или плагин OBS Audio Monitor.
 
 

--- a/player.py
+++ b/player.py
@@ -13,14 +13,20 @@ except Exception:  # pragma: no cover - optional dependency
 
 FFPLAY_PATH = os.path.join("ffmpeg", "bin", "ffplay.exe")
 
+# Output device name for routing audio through VB-CABLE
+AUDIO_OUT = "CABLE Input"
+
 
 def _play_file_ffplay(path: str) -> bool:
     """Play file using ffplay if available. Return True if successful."""
     if not os.path.exists(FFPLAY_PATH):
         return False
     try:
+        logging.info("Аудио выводится в устройство: %s", AUDIO_OUT)
         subprocess.run(
-            [FFPLAY_PATH, "-nodisp", "-autoexit", path],
+            [FFPLAY_PATH, "-nodisp", "-autoexit",
+             "-audio_device", AUDIO_OUT,
+             path],
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
             check=True,


### PR DESCRIPTION
## Summary
- define AUDIO_OUT constant for VB-CABLE
- send ffplay audio to `CABLE Input`
- log which device is used
- document VB-CABLE requirement and monitoring tips

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685506fa0a448329b5c089e4422adf0b